### PR TITLE
[Modtoberfest] Allow For Wall Torches On Path Blocks

### DIFF
--- a/src/main/java/io/github/steveplays28/pathunderfencegates/mixin/WallTorchBlockMixin.java
+++ b/src/main/java/io/github/steveplays28/pathunderfencegates/mixin/WallTorchBlockMixin.java
@@ -1,0 +1,29 @@
+package io.github.steveplays28.pathunderfencegates.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.WallTorchBlock;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.WorldView;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(WallTorchBlock.class)
+public class WallTorchBlockMixin {
+
+	@ModifyReturnValue(method = "canPlaceAt(Lnet/minecraft/world/WorldView;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/Direction;)Z", at = @At("RETURN"))
+	private static boolean pathUnderFenceGates$allowWallTorchesOnDirtPath(boolean original, @Local(argsOnly = true) WorldView world, @Local(argsOnly = true) BlockPos pos, @Local(argsOnly = true) Direction facing) {
+		//gets the blockpos of the block the torch is supposed to be connected to
+		BlockPos truePos = pos.offset(facing.getOpposite());
+		BlockState blockState = world.getBlockState(truePos);
+		if(blockState.getBlock() == Blocks.DIRT_PATH) {
+			//allow for wall torches on dirt path blocks
+			return true;
+		}
+		return original;
+	}
+
+}

--- a/src/main/resources/pathunderfencegates.mixins.json
+++ b/src/main/resources/pathunderfencegates.mixins.json
@@ -4,8 +4,9 @@
   "package": "io.github.steveplays28.pathunderfencegates.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "DirtPathBlockMixin",
     "ShovelItemMixin",
-    "DirtPathBlockMixin"
+    "WallTorchBlockMixin"
   ],
   "client": [],
   "injectors": {


### PR DESCRIPTION
Allows for torches to be placed on the sides of path blocks. Fixes #6 

![image](https://github.com/user-attachments/assets/6295d26b-8f38-4824-8224-3e368b7de0ed)

I believe, if desired, adding the ability to place hanging signs on the sides would be much easier because there is a tag list available, but I've left that for you to decide.

Per your request, the 1.21.x commit from #11 has been included with this PR, but no versioning changes has been made by me.

Anything can be changed as needed(including the approach to the mixin if you aren't too sure about it. I believe there are multiple ways of going about this, but this was the one I figured was best because it only affected torches).

Happy Modtoberfest!